### PR TITLE
Spelling mistakes on Axminster blog post

### DIFF
--- a/content/blog/2017-08-27-axminster-courses.md
+++ b/content/blog/2017-08-27-axminster-courses.md
@@ -2,7 +2,7 @@
 title: Axminster Courses 
 date: 2017-08-27
 layout: post
-published: false
+draft: true
 tags: []
 ---
 

--- a/content/blog/2017-08-27-axminster-courses.md
+++ b/content/blog/2017-08-27-axminster-courses.md
@@ -2,7 +2,7 @@
 title: Axminster Courses 
 date: 2017-08-27
 layout: post
-published: true
+published: false
 tags: []
 ---
 

--- a/content/blog/2017-08-27-axminster-courses.md
+++ b/content/blog/2017-08-27-axminster-courses.md
@@ -1,5 +1,5 @@
 ---
-title: Axeminster Courses 
+title: Axminster Courses 
 date: 2017-08-27
 layout: post
 published: true
@@ -8,11 +8,11 @@ tags: []
 
 {{% picture "2017-08-27-axminster-courses/3.jpg" %}}
 
-TinkerSoc have teamed up with Axeminster Tools to offer training courses at a reduced price.
+TinkerSoc have teamed up with Axminster Tools to offer training courses at a reduced price for its members.
 
 <!--more-->
 
-During the summer break some members took up the opertunity to go on the turning Motar & Pestle course.
+During the summer break some of our members went on the turning Motar & Pestle course at Axminster in Sittingbourne.
 
 {{% picture "2017-08-27-axminster-courses/1.jpg" %}}
 {{% picture "2017-08-27-axminster-courses/2.jpg" %}}


### PR DESCRIPTION
Axminster Tools & Machinery is spelled as in Axminster in Devon, the town in which they are based.

Now I've read this more carefully this reads a bit like a clumsy advert placement on our blog, and I am sort-of against that. The person changes from "our members went" to "we enjoyed" before and after the photos.

Perhaps we could get some of the members who went to write about their experiences rather than just placing some token "it was nice" text in followed by a list of courses. We should also be upfront about the prices.